### PR TITLE
Add extra unit after named arguments in val.ml.

### DIFF
--- a/src/val.ml
+++ b/src/val.ml
@@ -71,8 +71,8 @@ module Sig = struct
   let params_to_string params =
     let rec go acc = function
       | [] -> acc
-      (* extra unit param if last one is optional *)
-      | [Optional _ as p] -> sprintf "%s%s -> unit -> " acc (param_to_string p)
+      (* extra unit param if last one is optional or named *)
+      | [(Optional _ | Named _) as p] -> sprintf "%s%s -> unit -> " acc (param_to_string p)
       | p :: ps -> go (sprintf "%s%s -> " acc (param_to_string p)) ps in
     go "" params
 
@@ -420,7 +420,8 @@ module Impl = struct
   let params_to_string params =
     let rec go acc = function
       | [] -> acc
-      | [Optional _ as p] -> sprintf "%s%s () " acc (param_to_string p)
+      (* extra () param if last one is optional or named *)
+      | [(Optional _ | Named _) as p] -> sprintf "%s%s () " acc (param_to_string p)
       | p::ps -> go (sprintf "%s%s " acc (param_to_string p)) ps in
     go "" params
 


### PR DESCRIPTION
This PR adds an extra unit after non-optional named arguments.

See issue https://github.com/andrenth/kubecaml/issues/2 for motivation.

This behaviour is consistent with the popular [`deriving make` ppx](https://github.com/ocaml-ppx/ppx_deriving#plugin-make).

Another minor thing: would you consider renaming the `create` function `make` to make it even more consistent? :)