### PR TITLE
Rename "create" to "make" in generated code

### DIFF
--- a/src/gen.ml
+++ b/src/gen.ml
@@ -180,8 +180,8 @@ let definition_module ?(path = [])
         (Type.Impl.alias "t" param_type) in
     let create =
       Val.create
-        (Val.Sig.(pure "create" [positional param_type] "t"))
-        (Val.Impl.(identity "create" [positional "t" "t"])) in
+        (Val.Sig.(pure "make" [positional param_type] "t"))
+        (Val.Impl.(identity "make" [positional "t" "t"])) in
     ([typ], [create]) in
 
   let record_type () =
@@ -189,8 +189,8 @@ let definition_module ?(path = [])
     let sig_params, impl_params = params |> List.split in
     let create =
       Val.create
-        (Val.Sig.pure "create" sig_params "t")
-        (Val.Impl.record_constructor "create" impl_params) in
+        (Val.Sig.pure "make" sig_params "t")
+        (Val.Impl.record_constructor "make" impl_params) in
     let fields, values =
       List.fold_left
         (fun (fields, values) (name, schema) ->

--- a/src/type.mli
+++ b/src/type.mli
@@ -1,33 +1,63 @@
+(** Representation of OCaml types in signatures and implementations. *)
+
+(** {1 Signature types} *)
+
+(** Type declarations in signatures. *)
 module Sig : sig
   type t
 
   val abstract : ?descr:string -> string -> t
+  (** Signature item for abstract types.
+
+      [abstract ?descr ?is_record name] is a signature item for abstract types.
+      The [descr] argument will be used to generate the documentation string,
+      if provided. *)
+
   val unspecified : ?descr:string -> string -> t
 
   val to_string : ?indent:int -> t -> string
 end
 
+
+(** {1 Implementation types} *)
+
+(** Type declarations in signatures. *)
 module Impl : sig
   type t
 
   type record_field
-
-  val alias : string -> string -> t
-  val record : string -> record_field list -> t
-  val unspecified : string -> t
+  (** The type of record fields. *)
 
   val record_field : name:string
                   -> orig_name:string
                   -> type_:string
                   -> record_field
+  (** Constructor function for record fields. *)
+
+  val alias : string -> string -> t
+  val record : string -> record_field list -> t
+  val unspecified : string -> t
 
   val to_string : ?indent:int -> t -> string
 end
 
+
+(** {1 Type declarations} *)
+
 type t
+(** The type used to represent signature and implementation types. *)
 
 val create : Sig.t -> Impl.t -> t
+(** Constructs a type representation from a signature and implementation types.
+
+    The signature and implementation types are assumed to represent the same
+    type in the generated code, according to OCaml's semantics. *)
+
 val name : t -> string
+(** The name of the type as defined in the signature type. *)
 
 val signature : t -> Sig.t
+(** The signature type representation. *)
+
 val implementation : t -> Impl.t
+(** The implementation type representation. *)


### PR DESCRIPTION
As discussed in https://github.com/andrenth/ocaml-swagger/pull/1#issuecomment-414979522 this renames "create" into "make" in the generated code.

I tried integrating `ppx_deriving` make plugin but quickly realised that it would be difficult (if not impossible) to do so. It would work for implementations but not for signatures, where the type is abstract. The limitation is that `deriving make` requires a non-abstract record type to generate the constructor function.

I'm not sure if there is a programatic way to ask `ppx_deriving` to generate the "make" function. I started a discussion on the forum for this: https://discuss.ocaml.org/t/deriving-make-for-abstract-types-in-signatures/2548.

An alternative would be to _not_ use abstract representation for record types and instead mark them as `private`. Not sure if it's a good idea.

I also wanted to add that I'm very happy with your Kubernetes library generated with ocaml-swagger. My main motivation to rename "create" into "make" is based on [this small preprocessor](https://github.com/rizo/ppx_make_record) that simplifies the configuration syntax for large Kubernetes definitions.

Oh and I also started adding some comments, hope that's ok.