### PR TITLE
Treat missing additional_properties as the unit type

### DIFF
--- a/src/schema.ml
+++ b/src/schema.ml
@@ -35,9 +35,7 @@ let rec kind_to_string t =
               | None, Some `Integer -> "Object.Of_ints.t"
               | None, Some `Boolean -> "Object.Of_bools.t"
               | None, _ -> sprintf "(string * %s) list" (kind_to_string (create ~reference_base ~reference_root props)))
-          | None ->
-              failwith ("Schema.kind_to_string: object without "
-                        ^ "additional_properties"))
+          | None -> "unit")
       | `Array   ->
           let open Swagger_j in
           match t.raw.items with


### PR DESCRIPTION
This addresses #11 

As specified in http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.5.6 when this property is empty, we should treat it as an empty schema.

Thanks!