### PR TITLE
Treat "default" response codes as errors

### DIFF
--- a/src/gen.ml
+++ b/src/gen.ml
@@ -71,8 +71,11 @@ let resp_type ~reference_base ~reference_root (resp : Swagger_j.response) =
 
 let rec return_type ~reference_root ~reference_base (resps : Swagger_j.responses) =
   let is_error code =
-    let code = int_of_string code in
-    code < 200 || code >= 300 in
+    if String.lowercase_ascii code = "default"
+    then true
+    else
+      let code = int_of_string code in
+      code < 200 || code >= 300 in
   let responses_match (r1 : Swagger_j.response)
                       (r2 : Swagger_j.response) =
     r1.schema = r2.schema in

--- a/swagger.opam
+++ b/swagger.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-version: "0.1.0"
+version: "0.1.1"
 maintainer: "Andre Nathan <andre@hostnet.com.br>"
 authors: ["Andre Nathan <andre@hostnet.com.br>"]
 license: "MIT"


### PR DESCRIPTION
This should address #13 

From what I can grok in the code, error codes are simply skipped, so just treating "default" as an error should be enough.