### PR TITLE
Empty additional properties as the unit type

### DIFF
--- a/src/gen.ml
+++ b/src/gen.ml
@@ -239,6 +239,7 @@ let definition_module ?(path = [])
 
   let types, values =
     match schema.kind, schema.properties with
+    | Some `Object, _ -> record_type ()
     | Some _, _ -> alias_type ()
     | None, Some _ -> record_type ()
     | None, None -> unspec_type () in

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -35,9 +35,7 @@ let rec kind_to_string t =
               | None, Some `Integer -> "Object.Of_ints.t"
               | None, Some `Boolean -> "Object.Of_bools.t"
               | None, _ -> sprintf "(string * %s) list" (kind_to_string (create ~reference_base ~reference_root props)))
-          | None ->
-              failwith ("Schema.kind_to_string: object without "
-                        ^ "additional_properties"))
+          | None -> "unit")
       | `Array   ->
           let open Swagger_j in
           match t.raw.items with


### PR DESCRIPTION
Second attempt after #12. 

I ran a test against the [Kubernetes swagger.json](https://github.com/kubernetes/kubernetes/blob/master/api/openapi-spec/swagger.json) to test for regressions and there aren't any at least when looking at `diff` (so the same code is generated before and after this change). However it's possible that there's indeed a regression and I'm not seeing it.

This doesn't completely fix #11 because it depends on #14, and also there's an issue with the `snake_case` when `info.title` contains spaces. I'll open a separate PR for that one 😄 