### PR TITLE
Allow overriding the output module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ let () =
     ~definition_base:"io.k8s."
     ~reference_base:"#/definitions/io.k8s."
     ~reference_root:"Definitions"
+    ()
 ```
 
 This call instructs OCaml-Swagger to read the API specification from the file

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -325,10 +325,11 @@ let rec build_definitions ~root ~definition_base ~reference_base l =
 let of_swagger ?(path_base = "")
                ?(definition_base = "")
                ?(reference_base = "")
+               ?module_name
                ~reference_root s =
   let open Swagger_j in
   let definitions = default [] s.definitions in
-  let title = s.info.title in
+  let title = default s.info.title module_name in
   let defs =
     build_definitions
       ~root:(Mod.empty reference_root ~path:[title] ())

--- a/src/gen.mli
+++ b/src/gen.mli
@@ -1,6 +1,8 @@
 val of_swagger : ?path_base:string
               -> ?definition_base:string
-              -> ?reference_base:string -> reference_root:string
+              -> ?reference_base:string
+              -> ?module_name:string
+              -> reference_root:string
               -> Swagger_t.swagger
               -> Mod.t
 

--- a/src/swagger.ml
+++ b/src/swagger.ml
@@ -5,7 +5,8 @@ let codegen ~path_base
             ~reference_base
             ~reference_root
             ?(output = stdout)
-            ~input =
+            ?module_name
+            ~input () =
   let ic = open_in input in
   let s = really_input_string ic (in_channel_length ic) in
   let swagger = Swagger_j.swagger_of_string s in
@@ -14,6 +15,7 @@ let codegen ~path_base
     ~definition_base
     ~reference_base
     ~reference_root
+    ?module_name
     swagger
   |> Gen.to_string
   |> fprintf output "%s\n%!"

--- a/swagger.opam
+++ b/swagger.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-version: "0.1.1"
+version: "0.1.2"
 maintainer: "Andre Nathan <andre@hostnet.com.br>"
 authors: ["Andre Nathan <andre@hostnet.com.br>"]
 license: "MIT"


### PR DESCRIPTION
Allow an optional parameter to override the default
output module name which is based on the swagger
document title. The value is provided via a parameter
`module_name` via a string and it is still subject
to `snake_case`.

The background is: I'm using [this swagger spec](https://api.youneedabudget.com/papi/spec-v1-swagger.json)
which contains a title with spaces. The `snake_case`
function is not ready for that. I first tried to rewrite
that but it's quite important for the resulting output
so I decided to leave it as it is. This is a bit of a safer
change. Unfortunately it changes how the top-level call
is made (updated on the `README`).

Happy to make changes as requested :+1: 