### PR TITLE
Expose the Swagger_t and Swagger_j modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ $ opam install swagger
 
 ## Usage
 
-Most users will probably only need to use the `Swagger.codegen` function to
-parse an API specification and generate the OCaml code:
+Most users will probably only need to use the `Swagger.codegen` convenience
+function to parse an API specification and generate the OCaml code:
 
 ```ocaml
 let () =
@@ -41,7 +41,31 @@ let () =
     ~reference_root:"Definitions"
 ```
 
-This call instructs OCaml-Swagger to read the API specification from the file
+Alternatively, users can opt to only parse the API specification to modify it
+or traverse it as they wish:
+
+``` ocaml
+open Swagger
+
+let () =
+  (* Construct the data *)
+  let swagger : Swagger_t.swagger =
+    Swagger.swagger_of_input ~input:Sys.argv.(1) in
+
+  (* Say you want to modify the `title` *)
+  let swagger : Swagger_t.swagger =
+     { swagger with info = { swagger.info with title = "New_title" } } in
+
+  (* Generate the code *)
+  Swagger.codegen_swagger_to_string
+    ~swagger
+    ~path_base:"/"
+    ~definition_base:"io.k8s."
+    ~reference_base:"io.k8s."
+    ~reference_root:"Definitions"
+```
+
+These calls instruct OCaml-Swagger to read the API specification from the file
 name given in the first command-line argument and output the resulting code to
 the standard output.
 

--- a/src/gen.mli
+++ b/src/gen.mli
@@ -1,6 +1,7 @@
 val of_swagger : ?path_base:string
               -> ?definition_base:string
-              -> ?reference_base:string -> reference_root:string
+              -> ?reference_base:string
+              -> reference_root:string
               -> Swagger_t.swagger
               -> Mod.t
 

--- a/src/swagger.ml
+++ b/src/swagger.ml
@@ -1,14 +1,21 @@
 open Printf
 
-let codegen ~path_base
-            ~definition_base
-            ~reference_base
-            ~reference_root
-            ?(output = stdout)
-            ~input =
+module Swagger_j = Swagger_j
+module Swagger_t = Swagger_t
+module Gen       = Gen
+
+
+let swagger_of_input ~input =
   let ic = open_in input in
   let s = really_input_string ic (in_channel_length ic) in
-  let swagger = Swagger_j.swagger_of_string s in
+  Swagger_j.swagger_of_string s
+
+
+let codegen_swagger_to_string ~path_base
+                              ~definition_base
+                              ~reference_base
+                              ~reference_root
+                              ~swagger =
   Gen.of_swagger
     ~path_base
     ~definition_base
@@ -16,4 +23,19 @@ let codegen ~path_base
     ~reference_root
     swagger
   |> Gen.to_string
+
+
+let codegen ~path_base
+            ~definition_base
+            ~reference_base
+            ~reference_root
+            ?(output = stdout)
+            ~input =
+  let swagger = swagger_of_input ~input in
+  codegen_swagger_to_string
+    ~path_base
+    ~definition_base
+    ~reference_base
+    ~reference_root
+    ~swagger
   |> fprintf output "%s\n%!"

--- a/swagger.opam
+++ b/swagger.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-version: "0.1.1"
+version: "0.1.2"
 maintainer: "Andre Nathan <andre@hostnet.com.br>"
 authors: ["Andre Nathan <andre@hostnet.com.br>"]
 license: "MIT"


### PR DESCRIPTION
Alternative to #19 as discussed with @rizo.

Separate the `codegen` function into two separate functions: One for
parsing the API definitions, and one to generate the code from the
parsed data.

Keep the original function as a convenience function.

README updated accordingly.